### PR TITLE
Arbitrary code execution fix: Replace exec with execFile 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').exec;
+const exec = require('child_process').execFile;
 
 const COMMANDS = {
   darwin: 'open',
@@ -10,7 +10,7 @@ const command = COMMANDS[process.platform] || 'xdg-open';
 
 module.exports = function xopen(filepath) {
   return new Promise(function(resolve, reject) {
-    exec(command + ' ' + filepath, (error, stdout, stderr) => {
+    exec(command, [filepath], (error, stdout, stderr) => {
       if (error) {
         return reject(error);
       }


### PR DESCRIPTION
### 📊 Metadata *

Command Injection in `xopen`

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-xopen/

### ⚙️ Description *

Used child_process.execFile() instead of child_process.exec().

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. This PR replaces it with execFile() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```
// poc.js
var xopen =require("xopen");
xopen("& touch HACKED");
```

2. Execute the following commands in terminal:
```
npm i xopen # Install affected module
node poc.js #  Run the PoC
```

3.Check the Output using ls command before and after the execution.

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106955939-f11fa580-675b-11eb-95c8-4214fa30d1be.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106955874-d77e5e00-675b-11eb-815c-7addced83fc7.png)

### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1838
